### PR TITLE
feat: updated kingfisher to 1.59.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "name": "OCI Images",
   // Use a Dockerfile or Docker Compose file: https://containers.dev/guide/dockerfile
   // Use an image: https://github.com/devcontainers/images/blob/main/src/base-debian/history/1.0.9.md
-  "image": "ghcr.io/niceguyit/opensuse-base:v0.1.2-leap-15.6",
+  "image": "ghcr.io/niceguyit/opensuse-base:v0.1.3-leap-15.6",
   // Use 'postCreateCommand' to run commands after the container is created.
   "postCreateCommand": {
     // FIXME: It seems JetBrains does not run postCreateCommand as the user.

--- a/opensuse-base/config.yml
+++ b/opensuse-base/config.yml
@@ -58,7 +58,7 @@ binaries:
     - name: just
       version: "1.42.4"
     - name: kingfisher
-      version: "1.58.0"
+      version: "1.59.0"
     # FIXME: Upgrade Nebula to the latest.
     - name: nebula
       version: "1.8.0"


### PR DESCRIPTION
This updates `kingfisher` to be able to use commands such as `--exclude` and `--baseline-path`, so we can exclude certain glob patterns (or create a file that does) during secret scanning.