### PR TITLE
feat: Add Tactical RMM build process

### DIFF
--- a/.github/workflows/build-tactical-rmm.yml
+++ b/.github/workflows/build-tactical-rmm.yml
@@ -1,0 +1,65 @@
+---
+# Build every Tactical RMM image (backend, frontend, meshcentral, nats, nginx)
+# and push to GHCR. Any change under tactical-rmm/ triggers a rebuild of all
+# five so the published images stay in lockstep with the pinned upstream
+# release.
+name: Build Tactical RMM containers
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "tactical-rmm/**"
+      - ".github/workflows/build-tactical-rmm.yml"
+      - ".github/workflows/build-and-push-image.yml"
+
+jobs:
+  build-backend:
+    name: Build tactical-backend image
+    uses: ./.github/workflows/build-and-push-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: tactical-rmm
+      image-type: backend
+
+  build-frontend:
+    name: Build tactical-frontend image
+    uses: ./.github/workflows/build-and-push-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: tactical-rmm
+      image-type: frontend
+
+  build-meshcentral:
+    name: Build tactical-meshcentral image
+    uses: ./.github/workflows/build-and-push-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: tactical-rmm
+      image-type: meshcentral
+
+  build-nats:
+    name: Build tactical-nats image
+    uses: ./.github/workflows/build-and-push-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: tactical-rmm
+      image-type: nats
+
+  build-nginx:
+    name: Build tactical-nginx image
+    uses: ./.github/workflows/build-and-push-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: tactical-rmm
+      image-type: nginx

--- a/README.md
+++ b/README.md
@@ -81,3 +81,63 @@ instead of root.
 ```bash
 cd smartctl_exporter && ./build.nu base
 ```
+
+### Tactical RMM
+
+[Tactical RMM](https://github.com/amidaware/tacticalrmm) is built from the `tactical-rmm/` directory, which packages
+five custom images plus the stock `postgres:13-alpine` and `redis:6.0-alpine` dependencies. MeshCentral runs against
+its built-in NeDB store, so no MongoDB container is needed. The single shared `tactical-rmm/config.yml` pins the
+upstream Tactical RMM release; every image downloads the source tarball at that tag during build, so a version bump
+is a single-line change that rebuilds all five images together.
+
+
+| Image                  | Purpose                                                                   | Notes                                                                                                                                                                    |
+|------------------------|---------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `tactical-backend`     | Django API, Celery worker, Celery beat, Daphne websockets, init container | Single image dispatched by the entrypoint via the first argument (`tactical-init`, `tactical-backend`, `tactical-celery`, `tactical-celerybeat`, `tactical-websockets`). |
+| `tactical-frontend`    | Vue.js bundle on `nginx-unprivileged`                                     | The matching `tacticalrmm-web` release is pulled at build time using the `WEB_VERSION` recorded in upstream `settings.py`.                                               |
+| `tactical-meshcentral` | MeshCentral remote-access server                                          | The MeshCentral version is pulled from the upstream `MESH_VER` constant in `settings.py`. Uses the built-in NeDB store under `meshcentral-data` (no MongoDB required).   |
+| `tactical-nats`        | NATS server plus the upstream `nats-api` Go binary under `supervisord`    | Multi-arch aware: selects the upstream-shipped `nats-api` (amd64) or `nats-api-arm64` based on `TARGETARCH`.                                                             |
+| `tactical-nginx`       | TLS-terminating reverse proxy                                             | Generates a self-signed wildcard cert at start if `CERT_PUB_KEY` / `CERT_PRIV_KEY` are not provided.                                                                     |
+
+Build all five locally (single command):
+
+```bash
+cd tactical-rmm && ./build.nu
+```
+
+Or build a single component when iterating:
+
+```bash
+cd tactical-rmm && ./build.nu backend
+```
+
+Run the stack:
+
+```bash
+cd tactical-rmm
+cp .env.example .env
+# edit .env: hostnames, admin credentials, database passwords
+docker compose --file compose.example.yml up --detach
+```
+
+After the first start, watch `tactical-init` until it exits successfully (it creates the Django superuser, runs
+migrations, and writes the MeshCentral token). The web UI is served by `tactical-nginx` on `${TRMM_HTTPS_PORT}`.
+
+Verify a deployment end-to-end with `tactical-rmm/test.nu`. Given a domain (or explicit hosts) and an `X-API-KEY`, it
+exercises every public protocol surface in the stack: DNS, TLS, HTTP-to-HTTPS redirects, the Vue frontend SPA, the
+Django REST API (with and without auth), Django Channels websockets, the NATS websocket bridge, nginx static-file
+serving, and MeshCentral. The run is read-only: nothing in the deployment is mutated.
+
+```bash
+cd tactical-rmm
+./test.nu --domain example.com --api-key <KEY>
+
+# explicit per-host overrides
+./test.nu --app-host rmm.x.com --api-host api.x.com --mesh-host mesh.x.com --api-key <KEY>
+
+# self-signed certs + optional MeshCentral login probe
+./test.nu --domain example.com --api-key <KEY> --mesh-user tactical --mesh-pass <PASS> --insecure
+```
+
+Each test prints `[ PASS ]` or `[ FAIL ]` live; the script summarizes counts and exits non-zero on any failure, so it
+slots into a CI pipeline or a post-change check.

--- a/tactical-rmm/.env.example
+++ b/tactical-rmm/.env.example
@@ -1,0 +1,44 @@
+# Tactical RMM stack environment template. Copy to .env and edit.
+
+# --- Image source -----------------------------------------------------------
+# Set IMAGE_REPO to the registry prefix the images live under. The default in
+# compose.yml is ghcr.io/niceguyit/. Use an empty string to consume locally
+# built images (the tags produced by ./build.nu in each tactical-* directory).
+IMAGE_REPO=ghcr.io/niceguyit/
+VERSION=1.4.0
+
+# --- Hostnames --------------------------------------------------------------
+APP_HOST=rmm.example.com
+API_HOST=api.example.com
+MESH_HOST=mesh.example.com
+CSRF_COOKIE_DOMAIN=example.com
+SESSION_COOKIE_DOMAIN=example.com
+
+# --- TRMM admin -------------------------------------------------------------
+TRMM_USER=tactical
+TRMM_PASS=change_me_strong_password
+
+# --- MeshCentral admin ------------------------------------------------------
+MESH_USER=tactical
+MESH_PASS=change_me_strong_password
+
+# --- Databases --------------------------------------------------------------
+POSTGRES_USER=postgres
+POSTGRES_PASS=change_me_strong_password
+# MeshCentral uses its built-in NeDB store (no external database required).
+MESH_PERSISTENT_CONFIG=0
+
+# --- Feature toggles --------------------------------------------------------
+TRMM_DISABLE_WEB_TERMINAL=False
+TRMM_DISABLE_SERVER_SCRIPTS=False
+TRMM_DISABLE_SSO=False
+
+# --- HTTP / HTTPS ports -----------------------------------------------------
+TRMM_HTTP_PORT=80
+TRMM_HTTPS_PORT=443
+
+# --- TLS certificates -------------------------------------------------------
+# Base64-encoded PEM cert and key. Leave empty to have tactical-nginx
+# auto-generate a self-signed wildcard cert on first run.
+CERT_PUB_KEY=
+CERT_PRIV_KEY=

--- a/tactical-rmm/backend/Dockerfile
+++ b/tactical-rmm/backend/Dockerfile
@@ -1,0 +1,71 @@
+ARG TRMM_VERSION
+ARG BASE_IMAGE=python
+ARG BASE_TAG=3.11.8-slim
+
+# Stage 1: Fetch upstream Tactical RMM source at the pinned tag.
+FROM alpine:3 AS source
+
+ARG TRMM_VERSION
+
+RUN apk add --no-cache curl tar \
+	&& mkdir /src \
+	&& curl -fsSL "https://github.com/amidaware/tacticalrmm/archive/refs/tags/v${TRMM_VERSION}.tar.gz" \
+		| tar -xz -C /src --strip-components=1
+
+# Stage 2: Build Python virtualenv with API requirements.
+FROM ${BASE_IMAGE}:${BASE_TAG} AS venv
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV TACTICAL_TMP_DIR=/tmp/tactical
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+COPY --from=source /src/api/tacticalrmm/requirements.txt ${TACTICAL_TMP_DIR}/api/requirements.txt
+
+RUN python3 -m venv ${VIRTUAL_ENV} \
+	&& apt-get update \
+	&& apt-get install -y --no-install-recommends gcc libc6-dev \
+	&& pip install --no-cache-dir pip==25.1 \
+	&& pip install --no-cache-dir setuptools wheel \
+	&& pip install --no-cache-dir -r ${TACTICAL_TMP_DIR}/api/requirements.txt \
+	&& rm -rf /var/lib/apt/lists/*
+
+# Stage 3: Fetch the community-scripts repository.
+FROM alpine:3 AS scripts
+
+RUN apk add --no-cache git \
+	&& git clone --depth 1 https://github.com/amidaware/community-scripts.git /community-scripts
+
+# Stage 4: Runtime image.
+FROM ${BASE_IMAGE}:${BASE_TAG}
+
+ENV VIRTUAL_ENV=/opt/venv
+ENV TACTICAL_DIR=/opt/tactical
+ENV TACTICAL_TMP_DIR=/tmp/tactical
+ENV TACTICAL_READY_FILE=${TACTICAL_DIR}/tmp/tactical.ready
+ENV TACTICAL_USER=tactical
+ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+COPY --from=source /src/api/tacticalrmm ${TACTICAL_TMP_DIR}/api
+COPY --from=scripts /community-scripts ${TACTICAL_TMP_DIR}/community-scripts
+COPY --from=venv ${VIRTUAL_ENV} ${VIRTUAL_ENV}
+COPY --from=source /src/docker/containers/tactical/entrypoint.sh /entrypoint.sh
+
+RUN apt-get update \
+	&& apt-get upgrade -y \
+	&& apt-get install -y --no-install-recommends rsync weasyprint \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& groupadd -g 1000 "${TACTICAL_USER}" \
+	&& useradd -M -d "${TACTICAL_DIR}" -s /bin/bash -u 1000 -g 1000 "${TACTICAL_USER}" \
+	&& chmod +x /entrypoint.sh
+
+WORKDIR ${TACTICAL_DIR}/api
+
+EXPOSE 8080 4443 8383
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tactical-rmm/build.nu
+++ b/tactical-rmm/build.nu
@@ -1,0 +1,67 @@
+#!/usr/bin/env nu
+
+# Build a single Tactical RMM component, or all of them when no argument is given.
+#
+# Usage:
+#   ./build.nu                # build every component
+#   ./build.nu backend        # build only the backend
+#
+# Valid component names are read from config.yml (components.<name>).
+
+def build-component [
+	component: string			# Component key in config.yml (backend, frontend, ...)
+	config: record				# Parsed config.yml record
+] {
+	use std log
+
+	if not ($component in ($config.components | columns)) {
+		let valid = ($config.components | columns | str join ', ')
+		log error $"Invalid component: ($component). Valid components are: ($valid)"
+		exit 1
+	}
+
+	let comp = ($config.components | get $component)
+	let trmm_version = $config.tacticalrmm.version
+	let image_name = $comp.image_name
+	let image_version = $trmm_version
+
+	let context = ($env.FILE_PWD | path join $component)
+
+	log info $"Building ($image_name):($image_version) from ($context)"
+	(^docker buildx build
+		--build-arg $"TRMM_VERSION=($trmm_version)"
+		--build-arg $"BASE_IMAGE=($comp.base_image)"
+		--build-arg $"BASE_TAG=($comp.base_tag)"
+		--tag $"($image_name):($image_version)"
+		--load
+		$context)
+
+	log info $"Built image '($image_name):($image_version)'"
+
+	# Output for CI. Each component is built in its own job, so each run writes
+	# a single image=/tags= pair to GITHUB_OUTPUT.
+	mut output = "output.log"
+	if ("GITHUB_OUTPUT" in $env) {
+		$output = $env.GITHUB_OUTPUT
+	}
+	$"image=($image_name)\n" | save --append $output
+	$"tags=($image_version)\n" | save --append $output
+}
+
+def main [
+	component?: string			# Component name (backend, frontend, meshcentral, nats, nginx). Omit to build all.
+] {
+	use std log
+
+	let config_path = ($env.FILE_PWD | path join "config.yml")
+	let config = (open $config_path)
+
+	if ($component | is-empty) {
+		log info "No component specified, building all components"
+		for name in ($config.components | columns) {
+			build-component $name $config
+		}
+	} else {
+		build-component $component $config
+	}
+}

--- a/tactical-rmm/compose.example.yml
+++ b/tactical-rmm/compose.example.yml
@@ -1,0 +1,194 @@
+---
+# Tactical RMM stack.
+#
+# Brings up the five custom images (backend, frontend, meshcentral, nats, nginx)
+# plus the stock postgres and redis dependencies. MeshCentral runs against its
+# built-in NeDB store, so no MongoDB container is needed. Copy `.env.example`
+# to `.env`, fill in the secrets and host names, then `docker compose up -d`.
+#
+# IMAGE_REPO defaults to ghcr.io/niceguyit/ (the published location). Set it to
+# an empty string if you have built the images locally with `./build.nu base`
+# in each tactical-* directory and want to use those local tags directly.
+
+networks:
+  tactical-private:
+    name: tactical-private
+    driver: bridge
+
+volumes:
+  tactical-data:
+    name: tactical-data
+  tactical-meshcentral-data:
+    name: tactical-meshcentral-data
+  tactical-postgres:
+    name: tactical-postgres
+  tactical-redis:
+    name: tactical-redis
+
+services:
+  tactical-postgres:
+    image: postgres:13-alpine
+    restart: always
+    environment:
+      POSTGRES_DB: tacticalrmm
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASS}
+    volumes:
+      - tactical-postgres:/var/lib/postgresql/data
+    networks:
+      - tactical-private
+
+  tactical-redis:
+    image: redis:6.0-alpine
+    user: 1000:1000
+    command: redis-server
+    restart: always
+    volumes:
+      - tactical-redis:/data
+    networks:
+      - tactical-private
+
+  tactical-init:
+    image: ${IMAGE_REPO-ghcr.io/niceguyit/}tactical-backend:${VERSION}
+    restart: on-failure
+    command:
+      - tactical-init
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASS: ${POSTGRES_PASS}
+      APP_HOST: ${APP_HOST}
+      API_HOST: ${API_HOST}
+      CSRF_COOKIE_DOMAIN: ${CSRF_COOKIE_DOMAIN}
+      SESSION_COOKIE_DOMAIN: ${SESSION_COOKIE_DOMAIN}
+      MESH_USER: ${MESH_USER}
+      MESH_HOST: ${MESH_HOST}
+      TRMM_USER: ${TRMM_USER}
+      TRMM_PASS: ${TRMM_PASS}
+      TRMM_DISABLE_WEB_TERMINAL: ${TRMM_DISABLE_WEB_TERMINAL}
+      TRMM_DISABLE_SERVER_SCRIPTS: ${TRMM_DISABLE_SERVER_SCRIPTS}
+      TRMM_DISABLE_SSO: ${TRMM_DISABLE_SSO}
+    depends_on:
+      - tactical-postgres
+      - tactical-meshcentral
+      - tactical-redis
+    volumes:
+      - tactical-data:/opt/tactical
+      - tactical-meshcentral-data:/meshcentral-data
+      - tactical-redis:/redis/data
+    networks:
+      - tactical-private
+
+  tactical-nats:
+    image: ${IMAGE_REPO-ghcr.io/niceguyit/}tactical-nats:${VERSION}
+    user: 1000:1000
+    restart: always
+    environment:
+      API_HOST: ${API_HOST}
+    volumes:
+      - tactical-data:/opt/tactical
+    networks:
+      tactical-private:
+        aliases:
+          - ${API_HOST}
+
+  tactical-meshcentral:
+    image: ${IMAGE_REPO-ghcr.io/niceguyit/}tactical-meshcentral:${VERSION}
+    user: 1000:1000
+    restart: always
+    environment:
+      MESH_HOST: ${MESH_HOST}
+      MESH_USER: ${MESH_USER}
+      MESH_PASS: ${MESH_PASS}
+      MESH_PERSISTENT_CONFIG: ${MESH_PERSISTENT_CONFIG}
+      NGINX_HOST_IP: tactical-nginx
+    volumes:
+      - tactical-data:/opt/tactical
+      - tactical-meshcentral-data:/home/node/app/meshcentral-data
+    networks:
+      tactical-private:
+        aliases:
+          - ${MESH_HOST}
+
+  tactical-frontend:
+    image: ${IMAGE_REPO-ghcr.io/niceguyit/}tactical-frontend:${VERSION}
+    user: 1000:1000
+    restart: always
+    environment:
+      API_HOST: ${API_HOST}
+    volumes:
+      - tactical-data:/opt/tactical
+    networks:
+      - tactical-private
+
+  tactical-backend:
+    image: ${IMAGE_REPO-ghcr.io/niceguyit/}tactical-backend:${VERSION}
+    user: 1000:1000
+    command:
+      - tactical-backend
+    restart: always
+    volumes:
+      - tactical-data:/opt/tactical
+    depends_on:
+      - tactical-postgres
+    networks:
+      - tactical-private
+
+  tactical-websockets:
+    image: ${IMAGE_REPO-ghcr.io/niceguyit/}tactical-backend:${VERSION}
+    user: 1000:1000
+    command:
+      - tactical-websockets
+    restart: always
+    volumes:
+      - tactical-data:/opt/tactical
+    depends_on:
+      - tactical-postgres
+      - tactical-backend
+    networks:
+      - tactical-private
+
+  tactical-celery:
+    image: ${IMAGE_REPO-ghcr.io/niceguyit/}tactical-backend:${VERSION}
+    user: 1000:1000
+    command:
+      - tactical-celery
+    restart: always
+    volumes:
+      - tactical-data:/opt/tactical
+    depends_on:
+      - tactical-postgres
+      - tactical-redis
+    networks:
+      - tactical-private
+
+  tactical-celerybeat:
+    image: ${IMAGE_REPO-ghcr.io/niceguyit/}tactical-backend:${VERSION}
+    user: 1000:1000
+    command:
+      - tactical-celerybeat
+    restart: always
+    volumes:
+      - tactical-data:/opt/tactical
+    depends_on:
+      - tactical-postgres
+      - tactical-redis
+    networks:
+      - tactical-private
+
+  tactical-nginx:
+    image: ${IMAGE_REPO-ghcr.io/niceguyit/}tactical-nginx:${VERSION}
+    user: 1000:1000
+    restart: always
+    environment:
+      APP_HOST: ${APP_HOST}
+      API_HOST: ${API_HOST}
+      MESH_HOST: ${MESH_HOST}
+      CERT_PUB_KEY: ${CERT_PUB_KEY}
+      CERT_PRIV_KEY: ${CERT_PRIV_KEY}
+    ports:
+      - "${TRMM_HTTP_PORT-80}:8080"
+      - "${TRMM_HTTPS_PORT-443}:4443"
+    volumes:
+      - tactical-data:/opt/tactical
+    networks:
+      - tactical-private

--- a/tactical-rmm/config.yml
+++ b/tactical-rmm/config.yml
@@ -1,0 +1,31 @@
+---
+# Shared configuration for every Tactical RMM image. A single TRMM_VERSION
+# bump rebuilds backend, frontend, meshcentral, nats and nginx.
+
+tacticalrmm:
+  url: https://github.com/amidaware/tacticalrmm/releases
+  # The "v" prefix is added in build.nu when constructing the GitHub tarball URL.
+  version: 1.4.0
+
+components:
+  backend:
+    # Published image name. The tag tracks the Tactical RMM upstream version.
+    image_name: tactical-backend
+    base_image: python
+    base_tag: 3.11.8-slim
+  frontend:
+    image_name: tactical-frontend
+    base_image: nginxinc/nginx-unprivileged
+    base_tag: stable-alpine
+  meshcentral:
+    image_name: tactical-meshcentral
+    base_image: node
+    base_tag: 20-alpine
+  nats:
+    image_name: tactical-nats
+    base_image: nats
+    base_tag: 2.12.3-alpine
+  nginx:
+    image_name: tactical-nginx
+    base_image: nginxinc/nginx-unprivileged
+    base_tag: stable-alpine

--- a/tactical-rmm/frontend/Dockerfile
+++ b/tactical-rmm/frontend/Dockerfile
@@ -1,0 +1,55 @@
+ARG TRMM_VERSION
+ARG BASE_IMAGE=nginxinc/nginx-unprivileged
+ARG BASE_TAG=stable-alpine
+
+# Stage 1: Fetch upstream Tactical RMM source at the pinned tag.
+FROM alpine:3 AS source
+
+ARG TRMM_VERSION
+
+RUN apk add --no-cache curl tar \
+	&& mkdir /src \
+	&& curl -fsSL "https://github.com/amidaware/tacticalrmm/archive/refs/tags/v${TRMM_VERSION}.tar.gz" \
+		| tar -xz -C /src --strip-components=1
+
+# Stage 2: Download and unpack the matching tacticalrmm-web release.
+# WEB_VERSION is read from the upstream settings.py so the frontend tracks the backend.
+FROM alpine:3 AS web
+
+RUN apk add --no-cache bash wget tar grep
+
+COPY --from=source /src/api/tacticalrmm/tacticalrmm/settings.py /tmp/settings.py
+
+RUN WEB_VERSION=$(grep -o 'WEB_VERSION.*' /tmp/settings.py | cut -d'"' -f 2) \
+	&& mkdir -p /web \
+	&& wget -q "https://github.com/amidaware/tacticalrmm-web/releases/download/v${WEB_VERSION}/trmm-web-v${WEB_VERSION}.tar.gz" -O /tmp/web.tar.gz \
+	&& tar -xzf /tmp/web.tar.gz -C /web \
+	&& mv /web/dist/* /web/ \
+	&& rm -rf /web/dist /tmp/web.tar.gz
+
+# Stage 3: Runtime image.
+FROM ${BASE_IMAGE}:${BASE_TAG}
+
+ENV PUBLIC_DIR=/usr/share/nginx/html
+ENV TACTICAL_DIR=/opt/tactical
+ENV TACTICAL_READY_FILE=${TACTICAL_DIR}/tmp/tactical.ready
+
+USER root
+
+RUN deluser --remove-home nginx \
+	&& addgroup -S nginx -g 1000 \
+	&& adduser -S -G nginx -u 1000 nginx \
+	&& apk add --no-cache bash wget tar grep
+
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+COPY --from=web /web ${PUBLIC_DIR}
+COPY --from=source /src/docker/containers/tactical-frontend/entrypoint.sh /docker-entrypoint.d/entrypoint.sh
+
+RUN chown -R nginx:nginx /etc/nginx \
+	&& chown -R nginx:nginx ${PUBLIC_DIR} \
+	&& chmod +x /docker-entrypoint.d/entrypoint.sh
+
+USER nginx
+
+EXPOSE 8080

--- a/tactical-rmm/meshcentral/Dockerfile
+++ b/tactical-rmm/meshcentral/Dockerfile
@@ -1,0 +1,57 @@
+ARG TRMM_VERSION
+ARG BASE_IMAGE=node
+ARG BASE_TAG=20-alpine
+
+# Stage 1: Fetch upstream Tactical RMM source at the pinned tag.
+FROM alpine:3 AS source
+
+ARG TRMM_VERSION
+
+RUN apk add --no-cache curl tar \
+	&& mkdir /src \
+	&& curl -fsSL "https://github.com/amidaware/tacticalrmm/archive/refs/tags/v${TRMM_VERSION}.tar.gz" \
+		| tar -xz -C /src --strip-components=1
+
+# Stage 2: Runtime image. Installs MeshCentral at the version recorded in
+# upstream settings.py so the mesh server matches the backend's expectations.
+FROM ${BASE_IMAGE}:${BASE_TAG}
+
+WORKDIR /home/node/app
+
+ENV TACTICAL_DIR=/opt/tactical
+
+RUN apk add --no-cache bash
+
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+COPY --from=source /src/api/tacticalrmm/tacticalrmm/settings.py /tmp/settings.py
+# Local entrypoint replaces the upstream MongoDB-based one. Omitting the
+# "mongodb" key from the generated config makes MeshCentral fall back to its
+# built-in NeDB store under /home/node/app/meshcentral-data, removing the
+# external MongoDB container dependency.
+COPY entrypoint.sh /entrypoint.sh
+
+RUN MESH_VER=$(grep -o 'MESH_VER.*' /tmp/settings.py | cut -d'"' -f 2) \
+	&& cat > package.json <<EOF
+{
+  "dependencies": {
+    "archiver": "7.0.1",
+    "meshcentral": "${MESH_VER}",
+    "mongodb": "4.13.0",
+    "otplib": "10.2.3",
+    "pg": "8.7.1",
+    "pgtools": "0.3.2",
+    "saslprep": "1.0.3"
+  }
+}
+EOF
+
+RUN npm install \
+	&& chmod +x /entrypoint.sh \
+	&& chown -R node:node /home/node
+
+EXPOSE 8080 4443
+
+USER node
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tactical-rmm/meshcentral/entrypoint.sh
+++ b/tactical-rmm/meshcentral/entrypoint.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+#
+# MeshCentral entrypoint for Tactical RMM.
+#
+# Adapted from the upstream tactical-meshcentral entrypoint with the MongoDB
+# back end removed: omitting the "mongodb" key in settings makes MeshCentral
+# fall back to its built-in NeDB store under /home/node/app/meshcentral-data/.
+# That's the supported zero-dependency layout for current MeshCentral releases,
+# so the separate MongoDB container is no longer needed.
+
+set -e
+
+: "${MESH_USER:=meshcentral}"
+: "${MESH_PASS:=meshcentralpass}"
+: "${NGINX_HOST_IP:=tactical-nginx}"
+: "${NGINX_HOST_PORT:=4443}"
+: "${MESH_COMPRESSION_ENABLED:=false}"
+: "${MESH_PERSISTENT_CONFIG:=0}"
+: "${MESH_WEBRTC_ENABLED:=false}"
+: "${WS_MASK_OVERRIDE:=0}"
+: "${SMTP_HOST:=smtp.example.com}"
+: "${SMTP_PORT:=587}"
+: "${SMTP_FROM:=mesh@example.com}"
+: "${SMTP_USER:=mesh@example.com}"
+: "${SMTP_PASS:=mesh-smtp-pass}"
+: "${SMTP_TLS:=false}"
+
+if [ ! -f "/home/node/app/meshcentral-data/config.json" ] || [[ "${MESH_PERSISTENT_CONFIG}" -eq 0 ]]; then
+  cat >/home/node/app/meshcentral-data/config.json <<EOF
+{
+  "settings": {
+    "cert": "${MESH_HOST}",
+    "tlsOffload": "${NGINX_HOST_IP}",
+    "redirPort": 8080,
+    "WANonly": true,
+    "minify": 1,
+    "port": 4443,
+    "agentAliasPort": 443,
+    "aliasPort": 443,
+    "allowLoginToken": true,
+    "allowFraming": true,
+    "agentPing": 35,
+    "allowHighQualityDesktop": true,
+    "agentCoreDump": false,
+    "compression": ${MESH_COMPRESSION_ENABLED},
+    "wsCompression": ${MESH_COMPRESSION_ENABLED},
+    "agentWsCompression": ${MESH_COMPRESSION_ENABLED},
+    "webRTC": ${MESH_WEBRTC_ENABLED},
+    "maxInvalidLogin": {
+      "time": 5,
+      "count": 5,
+      "coolofftime": 30
+    }
+  },
+  "domains": {
+    "": {
+      "title": "Tactical RMM",
+      "title2": "TacticalRMM",
+      "newAccounts": false,
+      "mstsc": true,
+      "geoLocation": true,
+      "certUrl": "https://${NGINX_HOST_IP}:${NGINX_HOST_PORT}",
+      "agentConfig": [ "webSocketMaskOverride=${WS_MASK_OVERRIDE}" ]
+    }
+  },
+  "smtp": {
+    "host": "${SMTP_HOST}",
+    "port": ${SMTP_PORT},
+    "from": "${SMTP_FROM}",
+    "user": "${SMTP_USER}",
+    "pass": "${SMTP_PASS}",
+    "tls": ${SMTP_TLS}
+  }
+}
+EOF
+fi
+
+node node_modules/meshcentral --createaccount "${MESH_USER}" --pass "${MESH_PASS}" --email example@example.com
+node node_modules/meshcentral --adminaccount "${MESH_USER}"
+
+if [ ! -f "${TACTICAL_DIR}/tmp/mesh_token" ]; then
+  mesh_token=$(node node_modules/meshcentral --logintokenkey)
+
+  if [[ ${#mesh_token} -eq 160 ]]; then
+    echo "${mesh_token}" >"${TACTICAL_DIR}/tmp/mesh_token"
+  else
+    echo "Failed to generate mesh token. Fix the error and restart the mesh container"
+  fi
+fi
+
+until (echo >/dev/tcp/"${NGINX_HOST_IP}"/"${NGINX_HOST_PORT}") &>/dev/null; do
+  echo "waiting for nginx to start..."
+  sleep 5
+done
+
+node node_modules/meshcentral

--- a/tactical-rmm/nats/Dockerfile
+++ b/tactical-rmm/nats/Dockerfile
@@ -1,0 +1,51 @@
+ARG TRMM_VERSION
+ARG BASE_IMAGE=nats
+ARG BASE_TAG=2.12.3-alpine
+
+# Stage 1: Fetch upstream Tactical RMM source at the pinned tag.
+FROM alpine:3 AS source
+
+ARG TRMM_VERSION
+
+RUN apk add --no-cache curl tar \
+	&& mkdir /src \
+	&& curl -fsSL "https://github.com/amidaware/tacticalrmm/archive/refs/tags/v${TRMM_VERSION}.tar.gz" \
+		| tar -xz -C /src --strip-components=1
+
+# Stage 2: Runtime image. Bundles the pre-built nats-api binary that ships
+# in the upstream Tactical RMM repository.
+FROM ${BASE_IMAGE}:${BASE_TAG}
+
+ARG TARGETARCH
+
+ENV TACTICAL_DIR=/opt/tactical
+ENV TACTICAL_READY_FILE=${TACTICAL_DIR}/tmp/tactical.ready
+
+RUN apk add --no-cache supervisor bash
+
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+COPY --from=source /src/natsapi/bin/nats-api /tmp/nats-api-amd64
+COPY --from=source /src/natsapi/bin/nats-api-arm64 /tmp/nats-api-arm64
+COPY --from=source /src/docker/containers/tactical-nats/entrypoint.sh /entrypoint.sh
+
+# Select the binary that matches the build architecture (set by BuildKit).
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+		mv /tmp/nats-api-arm64 /usr/local/bin/nats-api; \
+	else \
+		mv /tmp/nats-api-amd64 /usr/local/bin/nats-api; \
+	fi \
+	&& rm -f /tmp/nats-api-* \
+	&& chmod +x /usr/local/bin/nats-api /entrypoint.sh
+
+RUN touch /usr/local/bin/config_watcher.sh \
+	&& chown 1000:1000 /usr/local/bin/config_watcher.sh \
+	&& mkdir -p /var/log/supervisor /etc/supervisor/conf.d \
+	&& touch /etc/supervisor/conf.d/supervisor.conf \
+	&& chown 1000:1000 /etc/supervisor/conf.d/supervisor.conf
+
+EXPOSE 4222 9235
+
+USER 1000
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/tactical-rmm/nginx/Dockerfile
+++ b/tactical-rmm/nginx/Dockerfile
@@ -1,0 +1,36 @@
+ARG TRMM_VERSION
+ARG BASE_IMAGE=nginxinc/nginx-unprivileged
+ARG BASE_TAG=stable-alpine
+
+# Stage 1: Fetch upstream Tactical RMM source at the pinned tag.
+FROM alpine:3 AS source
+
+ARG TRMM_VERSION
+
+RUN apk add --no-cache curl tar \
+	&& mkdir /src \
+	&& curl -fsSL "https://github.com/amidaware/tacticalrmm/archive/refs/tags/v${TRMM_VERSION}.tar.gz" \
+		| tar -xz -C /src --strip-components=1
+
+# Stage 2: Runtime image.
+FROM ${BASE_IMAGE}:${BASE_TAG}
+
+ENV TACTICAL_DIR=/opt/tactical
+
+USER root
+
+RUN deluser --remove-home nginx \
+	&& addgroup -S nginx -g 1000 \
+	&& adduser -S -G nginx -u 1000 nginx \
+	&& apk add --no-cache openssl bash \
+	&& chown -R nginx:nginx /etc/nginx
+
+SHELL ["/bin/bash", "-e", "-o", "pipefail", "-c"]
+
+COPY --from=source /src/docker/containers/tactical-nginx/entrypoint.sh /docker-entrypoint.d/entrypoint.sh
+
+RUN chmod +x /docker-entrypoint.d/entrypoint.sh
+
+USER nginx
+
+EXPOSE 4443 8080

--- a/tactical-rmm/test.nu
+++ b/tactical-rmm/test.nu
@@ -1,0 +1,387 @@
+#!/usr/bin/env nu
+#
+# Functional test for a Tactical RMM deployment.
+#
+# Exercises every public protocol surface so a single run answers "is the stack
+# healthy after my change?":
+#
+#   * DNS resolution for APP_HOST, API_HOST, MESH_HOST
+#   * TLS handshake on each host
+#   * HTTP -> HTTPS 301 redirect on each host
+#   * Vue frontend SPA load and asset fetch
+#   * Django REST API (X-API-KEY auth + reject on missing key)
+#   * Django Channels websocket upgrade (/ws/dashinfo/)
+#   * NATS websocket bridge upgrade (/natsws)
+#   * Django static file serving (/static/)
+#   * MeshCentral web UI reachable
+#   * MeshCentral login (when --mesh-user / --mesh-pass supplied)
+#
+# All tests are read-only; nothing in the deployment is mutated.
+#
+# Usage:
+#   ./test.nu --domain example.com --api-key <KEY>
+#   ./test.nu --app-host rmm.x.com --api-host api.x.com --mesh-host mesh.x.com --api-key <KEY>
+#   ./test.nu --domain example.com --api-key <KEY> --mesh-user tactical --mesh-pass secret --insecure
+#
+# Exit code: 0 when every test passes, 1 when any test fails.
+
+use std log
+
+# ----------------------------------------------------------------------------
+# Helpers
+
+# Resolve hosts from --domain or explicit overrides.
+def resolve-hosts [
+	domain: string
+	app: string
+	api: string
+	mesh: string
+]: nothing -> record {
+	if not ($domain | is-empty) {
+		return {
+			app: $"rmm.($domain)"
+			api: $"api.($domain)"
+			mesh: $"mesh.($domain)"
+		}
+	}
+	if ($app | is-empty) or ($api | is-empty) or ($mesh | is-empty) {
+		log error "Provide --domain, or all three of --app-host / --api-host / --mesh-host"
+		exit 2
+	}
+	{app: $app, api: $api, mesh: $mesh}
+}
+
+# Build the curl flag list that every request shares.
+def curl-base [insecure: bool, timeout: int]: nothing -> list<string> {
+	mut args = [
+		"--silent"
+		"--show-error"
+		"--max-time" ($timeout | into string)
+	]
+	if $insecure {
+		$args = ($args | append "--insecure")
+	}
+	$args
+}
+
+# Run curl and capture status code + body in a single call.
+# Returns {code: int, body: string, ok: bool, error: string}.
+def http-probe [
+	url: string
+	insecure: bool
+	timeout: int
+	--header (-H): list<string> = []
+	--method (-X): string = "GET"
+]: nothing -> record {
+	mut args = (curl-base $insecure $timeout)
+	$args = ($args | append ["--request" $method "--write-out" "\n%{http_code}"])
+	for h in $header {
+		$args = ($args | append ["--header" $h])
+	}
+	$args = ($args | append $url)
+
+	let out = (^curl ...$args | complete)
+	if $out.exit_code != 0 {
+		return {
+			code: 0
+			body: ""
+			ok: false
+			error: $"curl exit ($out.exit_code): ($out.stderr | str trim)"
+		}
+	}
+
+	let lines = ($out.stdout | lines)
+	let code = ($lines | last | into int)
+	let body = ($lines | drop 1 | str join "\n")
+	{code: $code, body: $body, ok: true, error: ""}
+}
+
+# Run a websocket upgrade probe via curl. Expects HTTP 101 on success;
+# 4xx is still useful evidence (proxy reached the upstream, upstream rejected
+# unauthenticated request) so we surface the code and let the caller decide.
+def ws-probe [
+	url: string
+	insecure: bool
+	timeout: int
+]: nothing -> record {
+	mut args = (curl-base $insecure $timeout)
+	$args = ($args | append [
+		"--http1.1"
+		"--include"
+		"--output" "/dev/null"
+		"--write-out" "%{http_code}"
+		"--header" "Connection: Upgrade"
+		"--header" "Upgrade: websocket"
+		"--header" "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ=="
+		"--header" "Sec-WebSocket-Version: 13"
+		$url
+	])
+	let out = (^curl ...$args | complete)
+	if $out.exit_code != 0 {
+		return {code: 0, ok: false, error: $"curl exit ($out.exit_code)"}
+	}
+	{code: ($out.stdout | into int), ok: true, error: ""}
+}
+
+# Append a result row, print live status, return the updated list.
+def record-result [
+	results: list<record>
+	name: string
+	ok: bool
+	detail: string
+]: nothing -> list<record> {
+	let tag = (if $ok { "[ PASS ]" } else { "[ FAIL ]" })
+	print $"($tag) ($name) -- ($detail)"
+	$results | append {name: $name, ok: $ok, detail: $detail}
+}
+
+# ----------------------------------------------------------------------------
+# Individual test groups
+
+def test-dns [hosts: record, results: list<record>]: nothing -> list<record> {
+	mut r = $results
+	for host in [$hosts.app $hosts.api $hosts.mesh] {
+		let probe = (^getent hosts $host | complete)
+		let ok = ($probe.exit_code == 0)
+		let detail = (if $ok { ($probe.stdout | str trim) } else { "no DNS record" })
+		$r = (record-result $r $"dns ($host)" $ok $detail)
+	}
+	$r
+}
+
+def test-tls [
+	hosts: record
+	insecure: bool
+	timeout: int
+	results: list<record>
+]: nothing -> list<record> {
+	mut r = $results
+	for host in [$hosts.app $hosts.api $hosts.mesh] {
+		let probe = (http-probe $"https://($host)/" $insecure $timeout)
+		let ok = ($probe.ok and $probe.code > 0)
+		let detail = (if $probe.ok {
+			$"HTTP ($probe.code)"
+		} else {
+			$probe.error
+		})
+		$r = (record-result $r $"tls ($host)" $ok $detail)
+	}
+	$r
+}
+
+def test-redirects [
+	hosts: record
+	timeout: int
+	results: list<record>
+]: nothing -> list<record> {
+	mut r = $results
+	for host in [$hosts.app $hosts.api $hosts.mesh] {
+		# Plain HTTP, follow no redirects, expect 301.
+		let probe = (http-probe $"http://($host)/" false $timeout)
+		let ok = ($probe.code == 301)
+		let detail = $"HTTP ($probe.code)"
+		$r = (record-result $r $"http->https redirect ($host)" $ok $detail)
+	}
+	$r
+}
+
+def test-frontend [
+	hosts: record
+	insecure: bool
+	timeout: int
+	results: list<record>
+]: nothing -> list<record> {
+	mut r = $results
+	let url = $"https://($hosts.app)/"
+	let probe = (http-probe $url $insecure $timeout)
+	let ok = ($probe.code == 200 and ($probe.body | str contains "<div id=\"app\""))
+	let detail = $"HTTP ($probe.code), SPA root marker ('<div id=\"app\"') ($ok)"
+	$r = (record-result $r "frontend SPA loads" $ok $detail)
+
+	# Pull a hashed asset URL out of the SPA HTML and fetch it. Vue/Vite emit
+	# /assets/ or hashed JS filenames in the document head.
+	let asset = (
+		$probe.body
+		| parse --regex '(?P<u>/(?:assets|js)/[A-Za-z0-9._-]+\.(?:js|css))'
+		| get --optional u.0
+	)
+	if ($asset | is-empty) {
+		return (record-result $r "frontend asset fetch" false "no asset URL found in SPA HTML")
+	}
+	let asset_probe = (http-probe $"https://($hosts.app)($asset)" $insecure $timeout)
+	let asset_ok = ($asset_probe.code == 200)
+	$r = (record-result $r "frontend asset fetch" $asset_ok $"GET ($asset) -> HTTP ($asset_probe.code)")
+	$r
+}
+
+def test-backend [
+	hosts: record
+	api_key: string
+	insecure: bool
+	timeout: int
+	results: list<record>
+]: nothing -> list<record> {
+	mut r = $results
+	let api = $"https://($hosts.api)"
+	let auth = [$"X-API-KEY: ($api_key)"]
+
+	# Reject missing key
+	let unauth = (http-probe $"($api)/core/version/" $insecure $timeout)
+	let unauth_ok = ($unauth.code == 401 or $unauth.code == 403)
+	$r = (record-result $r "backend rejects missing API key" $unauth_ok $"HTTP ($unauth.code) [expected 401 or 403]")
+
+	# Authenticated reads
+	let endpoints = [
+		"core/version/"
+		"core/dashinfo/"
+		"clients/"
+		"agents/"
+		"alerts/"
+		"scripts/"
+		"checks/"
+		"tasks/"
+		"automation/policies/"
+	]
+	for ep in $endpoints {
+		let probe = (http-probe --header $auth $"($api)/($ep)" $insecure $timeout)
+		let ok = ($probe.code >= 200 and $probe.code < 300)
+		$r = (record-result $r $"backend GET /($ep)" $ok $"HTTP ($probe.code)")
+	}
+	$r
+}
+
+def test-static [
+	hosts: record
+	insecure: bool
+	timeout: int
+	results: list<record>
+]: nothing -> list<record> {
+	# We don't know which exact static file exists, so prove nginx is serving
+	# the /static/ tree at all: a missing file under /static/ must come back as
+	# 404 from nginx (file not found), not 502/503/504 (upstream unreachable).
+	let probe = (http-probe $"https://($hosts.api)/static/__healthcheck__.txt" $insecure $timeout)
+	let ok = ($probe.code == 404 or ($probe.code >= 200 and $probe.code < 300))
+	let detail = $"HTTP ($probe.code) [404 from disk means nginx /static/ routing is healthy]"
+	record-result $results "nginx serves /static/" $ok $detail
+}
+
+def test-websockets [
+	hosts: record
+	insecure: bool
+	timeout: int
+	results: list<record>
+]: nothing -> list<record> {
+	mut r = $results
+
+	# Django Channels: nginx must proxy /ws/ to tactical-websockets. Without
+	# Knox auth the upstream returns 4xx, but the proxy hop must work.
+	let dash = (ws-probe $"https://($hosts.api)/ws/dashinfo/" $insecure $timeout)
+	let dash_ok = ($dash.code == 101 or ($dash.code >= 400 and $dash.code < 500))
+	$r = (record-result $r "websocket /ws/dashinfo/ upgrade reaches upstream" $dash_ok $"HTTP ($dash.code)")
+
+	# NATS websocket bridge
+	let nats = (ws-probe $"https://($hosts.api)/natsws" $insecure $timeout)
+	let nats_ok = ($nats.code == 101 or ($nats.code >= 400 and $nats.code < 500))
+	$r = (record-result $r "websocket /natsws upgrade reaches NATS" $nats_ok $"HTTP ($nats.code)")
+	$r
+}
+
+def test-mesh [
+	hosts: record
+	mesh_user: string
+	mesh_pass: string
+	insecure: bool
+	timeout: int
+	results: list<record>
+]: nothing -> list<record> {
+	mut r = $results
+	let mesh = $"https://($hosts.mesh)"
+
+	let root = (http-probe $mesh $insecure $timeout)
+	let root_ok = ($root.code == 200 and ($root.body | str contains "MeshCentral"))
+	$r = (record-result $r "MeshCentral web UI loads" $root_ok $"HTTP ($root.code), MeshCentral marker present ($root_ok)")
+
+	if ($mesh_user | is-empty) or ($mesh_pass | is-empty) {
+		print "       (mesh login skipped: --mesh-user / --mesh-pass not provided)"
+		return $r
+	}
+
+	# MeshCentral's login endpoint accepts form-encoded creds and either sets a
+	# session cookie (success) or 4xx (bad creds). Use --include so the response
+	# headers land in stdout and we can grep for Set-Cookie.
+	mut args = (curl-base $insecure $timeout)
+	$args = ($args | append [
+		"--include"
+		"--data-urlencode" $"username=($mesh_user)"
+		"--data-urlencode" $"password=($mesh_pass)"
+		$"($mesh)/login-handler"
+	])
+	let login = (^curl ...$args | complete)
+	let login_ok = ($login.stdout | str contains "Set-Cookie")
+	let detail = (if $login_ok {
+		"Set-Cookie present"
+	} else {
+		"no Set-Cookie -- auth rejected or endpoint moved"
+	})
+	$r = (record-result $r "MeshCentral login accepts credentials" $login_ok $detail)
+	$r
+}
+
+# ----------------------------------------------------------------------------
+# Main
+
+def main [
+	--domain: string = ""           # Root domain; APP/API/MESH derived as rmm./api./mesh.
+	--app-host: string = ""         # Override APP_HOST (e.g. rmm.example.com)
+	--api-host: string = ""         # Override API_HOST
+	--mesh-host: string = ""        # Override MESH_HOST
+	--api-key: string               # X-API-KEY for the Django backend (required)
+	--mesh-user: string = ""        # MeshCentral admin username (optional)
+	--mesh-pass: string = ""        # MeshCentral admin password (optional)
+	--insecure                      # Skip TLS verification (use for self-signed certs)
+	--timeout: int = 10             # Per-request timeout in seconds
+] {
+	if ($api_key | is-empty) {
+		log error "--api-key is required"
+		exit 2
+	}
+
+	let hosts = (resolve-hosts $domain $app_host $api_host $mesh_host)
+	let started = (date now)
+
+	print "Tactical RMM functional test"
+	print $"  app:    https://($hosts.app)"
+	print $"  api:    https://($hosts.api)"
+	print $"  mesh:   https://($hosts.mesh)"
+	print $"  insecure TLS: ($insecure)"
+	print $"  timeout: ($timeout)s"
+	print ""
+
+	mut results = []
+	$results = (test-dns $hosts $results)
+	$results = (test-tls $hosts $insecure $timeout $results)
+	$results = (test-redirects $hosts $timeout $results)
+	$results = (test-frontend $hosts $insecure $timeout $results)
+	$results = (test-backend $hosts $api_key $insecure $timeout $results)
+	$results = (test-static $hosts $insecure $timeout $results)
+	$results = (test-websockets $hosts $insecure $timeout $results)
+	$results = (test-mesh $hosts $mesh_user $mesh_pass $insecure $timeout $results)
+
+	let elapsed = ((date now) - $started)
+	let passed = ($results | where ok | length)
+	let failed = ($results | where { |r| not $r.ok } | length)
+	let total = ($results | length)
+
+	print ""
+	print $"-----------------------------------------------------------"
+	print $"($passed) passed, ($failed) failed, ($total) total -- elapsed ($elapsed)"
+
+	if $failed > 0 {
+		print ""
+		print "Failed tests:"
+		for r in ($results | where { |x| not $x.ok }) {
+			print $"  - ($r.name): ($r.detail)"
+		}
+		exit 1
+	}
+}


### PR DESCRIPTION
Add a build for the five custom Tactical RMM OCI images (backend, frontend, meshcentral, nats, nginx) plus a stack runner and a deployment smoke test. All images live under `tactical-rmm/` and pin a single upstream Tactical RMM release in `tactical-rmm/config.yml`; bumping the version rebuilds every image together.

A single `tactical-rmm/build.nu` orchestrator builds one component (`./build.nu backend`) or all five (`./build.nu`). Each Dockerfile downloads the upstream Tactical RMM source tarball at the pinned tag during a builder stage and copies only the files it needs, mirroring the existing coredns pattern. The frontend pulls the matching tacticalrmm-web release using the `WEB_VERSION` recorded in upstream `settings.py`, and the meshcentral image installs the MeshCentral version recorded as `MESH_VER`, so frontend and mesh stay locked to the backend automatically. The nats image is multi-arch aware via `TARGETARCH` and selects the upstream-shipped nats-api binary for amd64 or arm64.

CI is consolidated into one workflow `build-tactical-rmm.yml` with five parallel jobs (matching the existing opensuse-base pattern). Any change under `tactical-rmm/**` rebuilds and pushes all five images so the published set never drifts.

The MongoDB container is removed. A vendored `tactical-rmm/meshcentral/entrypoint.sh` replaces the upstream MongoDB-based one and generates a config without the `mongodb` setting, so MeshCentral falls back to its built-in NeDB store. The compose example, env example, and README are updated to drop MongoDB.

`tactical-rmm/compose.example.yml` (renamed from a top-level `compose.yml`) wires the five custom images plus stock postgres/redis. Volumes follow the project naming convention (`tactical-data`, `tactical-postgres`, `tactical-redis`, `tactical-meshcentral-data`). `.env.example` is the env template.

`tactical-rmm/test.nu` is a Nushell post-deployment smoke test. Given a domain (or explicit hosts) and an `X-API-KEY`, it exercises every protocol surface (DNS, TLS, HTTP-to-HTTPS redirects, frontend SPA, Django REST API with and without auth, Django Channels websockets, NATS websocket bridge, nginx static-file serving, MeshCentral) read-only and exits non-zero on any failure so it slots into a CI step.