### PR TITLE
fix: Remove nu_plugin_query from binary downloads

### DIFF
--- a/opensuse-base/config.yml
+++ b/opensuse-base/config.yml
@@ -159,9 +159,6 @@ binaries:
     - name: nu
       version: "0.112.2"
       file: nu_plugin_polars
-    - name: nu
-      version: "0.112.2"
-      file: nu_plugin_query
     - name: ouch
       version: "0.7.1"
     - name: pinger


### PR DESCRIPTION
nu_plugin_query no longer published to Dufs; download fails with 404 and breaks the opensuse-base build.