### PR TITLE
feat(rust-builder): three-tier Rust toolchain builder image

### DIFF
--- a/.github/workflows/build-rust-builder.yml
+++ b/.github/workflows/build-rust-builder.yml
@@ -1,0 +1,44 @@
+---
+# Build rust-builder images and push to GHCR.
+name: Build rust-builder container
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "rust-builder/**"
+      - ".github/workflows/build-rust-builder.yml"
+      - ".github/workflows/build-and-push-image.yml"
+
+jobs:
+  build-base:
+    name: Build rust-builder base image
+    uses: ./.github/workflows/build-and-push-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: rust-builder
+      image-type: base
+
+  build-dioxus:
+    name: Build rust-builder dioxus image
+    needs: build-base
+    uses: ./.github/workflows/build-and-push-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: rust-builder
+      image-type: dioxus
+
+  build-dioxus-desktop:
+    name: Build rust-builder dioxus-desktop image
+    needs: build-dioxus
+    uses: ./.github/workflows/build-and-push-image.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      image-name: rust-builder
+      image-type: dioxus-desktop

--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ cd opensuse-base && ./build.nu base
 cd opensuse-base && ./build.nu dev
 ```
 
+### Rust builder
+
+The `rust-builder` images are pre-baked Rust toolchain images for downstream OCI builds. They eliminate the per-repo
+`apt-get install`, `cargo binstall dioxus-cli`, and `rustup target add wasm32-unknown-unknown` steps that otherwise
+re-run on every cold build. Three variants, each published as its own image:
+
+1. **base** (`rust-builder`) - Rust 1.93 + pkg-config, libssl-dev, build-essential, lld, ca-certificates,
+   curl, unzip + the WASM target + `cargo-binstall`. For generic Rust services with no Dioxus.
+2. **dioxus** (`rust-builder-dioxus`) - Adds Bun (Tailwind builds) and pinned `dioxus-cli` (0.7.7).
+   For server-rendered or WASM Dioxus apps.
+3. **dioxus-desktop** (`rust-builder-dioxus-desktop`) - Adds GTK / WebKitGTK / libxdo / appindicator / librsvg.
+   For Dioxus desktop builds (wry renderer).
+
+Versions and pins live in `rust-builder/config.yml`; bump there to roll a new tag.
+
+```bash
+cd rust-builder && ./build.nu base
+cd rust-builder && ./build.nu dioxus
+cd rust-builder && ./build.nu dioxus-desktop
+```
+
 ### WordPress
 
 The `wordpress` image extends the official `wordpress:6.8.1-php8.4-fpm-alpine` image with additional PHP extensions:

--- a/opensuse-base/config.yml
+++ b/opensuse-base/config.yml
@@ -9,7 +9,7 @@ opensuse:
 
 published:
   # The openSUSE name and version are appended: v0.1.1-leap-15.6
-  version: "v1.1.0"
+  version: "v1.2.0"
   base:
     # Published image name and version
     name: "opensuse-base"
@@ -29,6 +29,7 @@ packages:
     - tar
     - gzip
     - bzip2
+    - zip
     - unzip
     - zstd
     - which

--- a/rust-builder/Dockerfile
+++ b/rust-builder/Dockerfile
@@ -1,0 +1,59 @@
+# Three-tier Rust builder image. Each named stage is a separate published
+# image; consumers pick the closest tier.
+#
+#   base             - Rust toolchain + common build deps + cargo-binstall
+#                      (generic Rust services with no Dioxus / WebKit).
+#   dioxus           - Adds bun (Tailwind) + pinned dioxus-cli.
+#                      For server-rendered or WASM Dioxus apps.
+#   dioxus-desktop   - Adds GTK / WebKitGTK + libxdo + appindicator + librsvg.
+#                      For Dioxus desktop builds (wry renderer).
+
+ARG RUST_VERSION=1.93
+ARG DEBIAN_VARIANT=trixie
+
+# ---------------------------------------------------------------------------
+# Stage: base
+# ---------------------------------------------------------------------------
+FROM rust:${RUST_VERSION}-slim-${DEBIAN_VARIANT} AS base
+
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+        ca-certificates \
+        curl \
+        pkg-config \
+        libssl-dev \
+        build-essential \
+        lld \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add wasm32-unknown-unknown
+
+RUN curl --location --silent --show-error \
+        https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-x86_64-unknown-linux-gnu.tgz \
+    | tar --extract --gzip --directory /usr/local/cargo/bin
+
+# ---------------------------------------------------------------------------
+# Stage: dioxus
+# ---------------------------------------------------------------------------
+FROM base AS dioxus
+
+ARG DIOXUS_CLI_VERSION=0.7.7
+
+# Bun for Tailwind CSS / asset bundling.
+RUN curl --fail --location --silent --show-error https://bun.sh/install | bash \
+    && cp /root/.bun/bin/bun /usr/local/bin/bun
+ENV PATH="/root/.bun/bin:${PATH}"
+
+RUN cargo binstall dioxus-cli@${DIOXUS_CLI_VERSION} --no-confirm
+
+# ---------------------------------------------------------------------------
+# Stage: dioxus-desktop
+# ---------------------------------------------------------------------------
+FROM dioxus AS dioxus-desktop
+
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+        libwebkit2gtk-4.1-dev \
+        libxdo-dev \
+        libayatana-appindicator3-dev \
+        librsvg2-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/rust-builder/build.nu
+++ b/rust-builder/build.nu
@@ -1,0 +1,98 @@
+#!/usr/bin/env nu
+
+# Build a rust-builder image variant via `docker buildx build --target <variant>`.
+# Tags are computed from config.yml and written to $GITHUB_OUTPUT (CI) or output.log (local).
+
+const valid_variants = ['base' 'dioxus' 'dioxus-desktop']
+
+# Load config.yml and derive the version-tag suffixes used to tag every image.
+def load-config []: [nothing -> any] {
+	try {
+		let config = (open config.yml)
+
+		# Suffix common to every tag for the base image: <rust>-<debian>.
+		let base_suffix = ([
+			$"rust($config.rust.version)"
+			$config.debian.variant
+		] | str join '-')
+
+		# Suffix for the dioxus + dioxus-desktop variants additionally encodes
+		# the pinned dioxus-cli version.
+		let dioxus_suffix = ([
+			$"dioxus($config.dioxus.version)"
+			$base_suffix
+		] | str join '-')
+
+		# Semver-compatible shortened versions.
+		let version_parts = ($config.published.version | split row '.')
+		let major = ($version_parts | first 1 | str join)
+		let minor = ($version_parts | first 2 | str join '.')
+
+		$config
+		| upsert published.major_version $major
+		| upsert published.minor_version $minor
+		| upsert published.base_suffix $base_suffix
+		| upsert published.dioxus_suffix $dioxus_suffix
+	} catch {|err|
+		use std log
+		log error $"[load-config] Failed to load config: ($err.msg)"
+		exit 1
+	}
+}
+
+# Compute the tag list for a given variant.
+def compute-tags [config: any, variant: string]: [nothing -> list<string>] {
+	# 'base' uses the rust+debian suffix only; dioxus and dioxus-desktop also
+	# encode the dioxus-cli version.
+	let suffix = if $variant == 'base' {
+		$config.published.base_suffix
+	} else {
+		$config.published.dioxus_suffix
+	}
+
+	[
+		$"($config.published.version)-($suffix)"
+		$"($config.published.minor_version)-($suffix)"
+		$"($config.published.major_version)-($suffix)"
+		$"latest-($suffix)"
+		'latest'
+	]
+}
+
+# Main script.
+def main [
+	variant		# Stage to build: base | dioxus | dioxus-desktop
+] {
+	use std log
+
+	if not ($variant in $valid_variants) {
+		log error $"Invalid variant: ($variant). Valid: ($valid_variants | str join ', ')"
+		exit 1
+	}
+
+	let config = (load-config)
+	let image = ($config.published.variants | get $variant | get name)
+	let tags = (compute-tags $config $variant)
+	let tag_args = ($tags | each {|t| ['--tag' $"($image):($t)"]} | flatten)
+
+	log info $"Building ($image) target=($variant) with tags: ($tags | str join ', ')"
+
+	(^docker buildx build
+		--target $variant
+		--build-arg $"RUST_VERSION=($config.rust.version)"
+		--build-arg $"DEBIAN_VARIANT=($config.debian.variant)"
+		--build-arg $"DIOXUS_CLI_VERSION=($config.dioxus.version)"
+		...$tag_args
+		--load
+		.)
+
+	log info $"Built image '($image)' with ($tags | length) tags"
+
+	# Output for CI / local debugging.
+	mut output = "output.log"
+	if ("GITHUB_OUTPUT" in $env) {
+		$output = $env.GITHUB_OUTPUT
+	}
+	$"image=($image)\n" | save --append $output
+	$"tags=($tags | str join ' ')\n" | save --append $output
+}

--- a/rust-builder/config.yml
+++ b/rust-builder/config.yml
@@ -1,0 +1,29 @@
+---
+# Rust builder image versions and tag inputs.
+
+rust:
+  # Pinned Rust toolchain. Bumping this requires testing every consumer.
+  version: "1.93"
+
+debian:
+  # Debian codename for the rust:<version>-slim-<variant> base image.
+  # Trixie ships glibc 2.41, required by the pre-built dioxus-cli binary.
+  variant: trixie
+
+dioxus:
+  # Pinned dioxus-cli version installed in the dioxus stage. Must match the
+  # dioxus crate version pinned in consumer Cargo.toml files.
+  version: "0.7.7"
+
+published:
+  # Published image version. Bump when any layer changes.
+  version: v1.0.0
+
+  # Each variant maps to a Dockerfile stage and is published as its own image.
+  variants:
+    base:
+      name: rust-builder
+    dioxus:
+      name: rust-builder-dioxus
+    dioxus-desktop:
+      name: rust-builder-dioxus-desktop


### PR DESCRIPTION
Adds a multi-stage Rust builder image set that consumer Dockerfiles can FROM in place of `rust:1.93-slim-trixie`. Each variant ships pre-installed dependencies that previously had to be apt-installed and binstalled on every cold OCI build.

- `rust-builder` (base): Rust 1.93 + pkg-config, libssl-dev, build-essential, lld, ca-certificates, curl, unzip + the WASM target + cargo-binstall.
- `rust-builder-dioxus`: extends base, adds Bun + dioxus-cli pinned to 0.7.7.
- `rust-builder-dioxus-desktop`: extends dioxus, adds GTK / WebKitGTK / libxdo / appindicator / librsvg.

Versions and pins live in `rust-builder/config.yml`; bumping there rolls a fresh tag set. Tags encode rust + debian for the base variant and additionally encode dioxus for the dioxus variants, so consumers can pin to whichever level of churn they care about.

Wires the three variants into a sequential GitHub Actions pipeline (`build-rust-builder.yml`) that reuses the existing `build-and-push-image.yml`. Sequencing matters: dioxus needs base in the local Docker daemon before its own buildx invocation can pull from cache.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>