### PR TITLE
feat(opensuse-base): cargo + bun on PATH for login shells, pre-instal…

### DIFF
--- a/opensuse-base/config.yml
+++ b/opensuse-base/config.yml
@@ -9,7 +9,7 @@ opensuse:
 
 published:
   # The openSUSE name and version are appended: v0.1.1-leap-15.6
-  version: "v1.2.0"
+  version: "v1.3.0"
   base:
     # Published image name and version
     name: "opensuse-base"
@@ -117,7 +117,7 @@ rust:
   # Note: Rust has a 6-week release cycle and only the latest stable version is officially supported.
   # There's no long-term support (LTS) model.
   # Possible value: stable
-  version: "1.93"
+  version: "1.94"
 
 binaries:
   host: dufs.niceguyit.biz

--- a/opensuse-base/setup.nu
+++ b/opensuse-base/setup.nu
@@ -88,6 +88,17 @@ def "main add-user" [] {
 	# Register nu as a valid shell
 	"/usr/local/bin/nu\n" | save --append /etc/shells
 
+	# Make user-installed binaries (cargo, bun, etc.) discoverable to login
+	# shells: ssh sessions for JetBrains Remote, VS Code devcontainer
+	# userEnvProbe, bash --login.  /etc/profile.d/*.sh is sourced by
+	# /etc/profile, so anything dropped here lands on PATH for every login.
+	let user_home = $"/home/($container_user)"
+	let path_line = (
+		'export PATH="' + $user_home + '/.cargo/bin:' + $user_home + '/.bun/bin:$PATH"' + "\n"
+	)
+	$path_line | save /etc/profile.d/dev-paths.sh
+	chmod a+r /etc/profile.d/dev-paths.sh
+
 	# Create user with docker group access
 	^useradd --groups 'users,docker' --shell $login_shell --create-home $container_user
 
@@ -149,6 +160,15 @@ def "main install-user-tools" [
 		chmod a+x $rustup
 		^$rustup -y --no-modify-path --default-toolchain $rust_version
 		rm $rustup
+
+		# Pre-install rustup components and targets every Rust check.yml in
+		# the org expects: clippy + rustfmt for `cargo clippy` / `cargo fmt
+		# --check`, wasm32 target for Dioxus / Yew / generic WASM builds.
+		# Without these the workflow has to `rustup component add` on every
+		# job and the runner image is incomplete out of the box.
+		let rustup_bin = $"($env.HOME)/.cargo/bin/rustup"
+		^$rustup_bin component add clippy rustfmt
+		^$rustup_bin target add wasm32-unknown-unknown
 	} else {
 		print 'Failed to download rustup'
 	}


### PR DESCRIPTION
…l Rust components

Two changes that close a gap surfaced by the first Rust check.yml run on the new runner image:

1. `setup.nu::add-user` writes `/etc/profile.d/dev-paths.sh` exporting `/home/dev/.cargo/bin` and `/home/dev/.bun/bin` onto `$PATH`. /etc/profile.d/*.sh is sourced by every login shell - ssh (JetBrains Remote), VS Code devcontainer userEnvProbe, bash --login. The previous image had `rustup` and `bun` installed under the dev user's home but no system-wide PATH hook, so non-login docker exec sessions and ssh sessions both failed to resolve them. Doing this at the OS level rather than via Dockerfile ENV means devcontainers pick it up too (Dockerfile ENV does not propagate to ssh-spawned shells).

2. `setup.nu::install-user-tools` now runs `rustup component add clippy rustfmt` and `rustup target add wasm32-unknown-unknown` after the rustup install. Every Rust check.yml in the org expects these to be present; without them each CI job had to bootstrap them itself.

Bumps `published.version` to v1.3.0 and `rust.version` to 1.94 (matching the new rust-builder-* images).