### PR TITLE
feat(opensuse-base): export PATH for non-login shells too (act / dock…

### DIFF
--- a/opensuse-base/Dockerfile
+++ b/opensuse-base/Dockerfile
@@ -26,6 +26,13 @@ RUN nu /tmp/build/setup.nu add-user
 USER dev
 RUN nu --login --commands "nu /tmp/build/setup.nu install-user-tools --variant base"
 
+# Make user-installed binaries discoverable to non-login shells (`docker exec`,
+# act CI, anything that doesn't go through PAM). Login shells / ssh sessions /
+# devcontainer userEnvProbe get the same PATH from /etc/profile.d/dev-paths.sh
+# written by setup.nu::add-user; this ENV is the second half of the same wiring
+# for environments that inherit Docker's image metadata directly.
+ENV PATH="/home/dev/.cargo/bin:/home/dev/.bun/bin:${PATH}"
+
 # ---- Stage: dev (extends base) ----
 FROM base AS dev
 

--- a/opensuse-base/config.yml
+++ b/opensuse-base/config.yml
@@ -9,7 +9,7 @@ opensuse:
 
 published:
   # The openSUSE name and version are appended: v0.1.1-leap-15.6
-  version: "v1.3.0"
+  version: "v1.3.1"
   base:
     # Published image name and version
     name: "opensuse-base"


### PR DESCRIPTION
…er exec)

v1.3.0 added /etc/profile.d/dev-paths.sh which puts /home/dev/.cargo/bin and /home/dev/.bun/bin on PATH for login shells: ssh sessions, VS Code devcontainer userEnvProbe, bash --login. That covers the human-facing surfaces but missed `docker exec`-style invocations like act, where the runner spawns `bash -e` non-interactively against the container and never sources /etc/profile.d. PATH lookup fell back to the default `/usr/local/sbin:...:/bin` set, so `cargo`, `rustup`, and `bun` were not findable, even though they are installed in the image. Every Rust check.yml in the org therefore had to add an `echo "/home/dev/.cargo/bin" >> $GITHUB_PATH` step to compensate.

This change adds an `ENV PATH=...` directive at the end of the base stage so `docker exec` (and anything that inherits the image's environment) also sees the same PATH. Together with the existing /etc/profile.d/dev-paths.sh, every entry point - login or non-login, ssh or docker exec - lands on the same PATH set, and consumer pipelines drop the per-job PATH-setup workaround.

Bumps published.version to v1.3.1.