### PR TITLE
feat(frankenphp-wordpress): bump PHP 8.5, WordPress 6.9.4, append PHP…

### DIFF
--- a/frankenphp-wordpress/build.nu
+++ b/frankenphp-wordpress/build.nu
@@ -11,7 +11,9 @@ def main [] {
 	let php_extensions = ($config.php.extensions | str replace --all "\n" "" | str trim)
 	let caddy_modules = ($config.caddy_modules | str replace --all "\n" "" | str trim)
 	let published_name = $config.published.name
-	let published_version = $config.published.version
+	# Image tag pins the PHP version so the same image version can be rebuilt against
+	# a new PHP minor without colliding: frankenphp-wordpress:v0.1.0-php8.5
+	let published_version = $"($config.published.version)-php($php_version)"
 
 	# Compute WordPress image tag for the source stage
 	let wordpress_tag = $"($wordpress_version)-php($php_version)-fpm-alpine"

--- a/frankenphp-wordpress/config.yml
+++ b/frankenphp-wordpress/config.yml
@@ -1,12 +1,16 @@
 ---
 # The variables are separated out to make it easier to update.
 
+# https://hub.docker.com/_/wordpress
 wordpress:
-  url: https://hub.docker.com/_/wordpress
-  version: "6.8.1"
+  version: "6.9.4"
 
+# https://www.php.net/supported-versions.php
+# Extensions are compiled into the static FrankenPHP binary by static-php-cli.
+# Pinned versions live in spc's source manifest.
+# Redis: https://pecl.php.net/package/redis
 php:
-  version: "8.4"
+  version: "8.5"
   extensions: >-
     bcmath,ctype,curl,dom,exif,fileinfo,filter,gd,iconv,imagick,intl,
     ldap,mbregex,mbstring,mysqli,mysqlnd,opcache,openssl,pdo,pdo_mysql,
@@ -20,9 +24,9 @@ caddy_modules: >-
   --with github.com/dunglas/caddy-cbrotli
   --with github.com/dunglas/mercure/caddy
   --with github.com/dunglas/vulcain/caddy
-  --with github.com/stephenmiracle/frankenwp/sidekick/middleware/cache=./cache
 
 published:
-  # Published image name and version
+  # Published image name and version. PHP version is appended in build.nu so the
+  # final tag looks like: frankenphp-wordpress:v0.1.0-php8.5
   name: "frankenphp-wordpress"
   version: "v0.1.0"


### PR DESCRIPTION
… version to image tag

Image tag now includes the PHP version (frankenphp-wordpress:v0.1.0-php8.5) so different PHP minors can coexist under the same image version. Restores upstream `url` properties as comments on the wordpress/php sections for navigation. Drops the caddy_modules frankenwp cache middleware entry.