### PR TITLE
fix(rust-builder-glibc): publish v1.0.1 with non-root bun/bunx

### DIFF
--- a/rust-builder-glibc/Dockerfile
+++ b/rust-builder-glibc/Dockerfile
@@ -72,7 +72,11 @@ RUN curl --location --silent --show-error \
 # Bun for Tailwind / asset bundling. Installed directly under /usr/local so
 # the binaries land at /usr/local/bin/{bun,bunx}: world-readable, already on
 # PATH, and reachable by non-root consumers without traversing /root (mode 700).
-RUN curl --fail --location --silent --show-error https://bun.sh/install | env BUN_INSTALL=/usr/local bash
+# `bunx` ships in the release zip rather than being created by the installer, so
+# smoke-test both: fail the build if upstream ever stops shipping bunx.
+RUN curl --fail --location --silent --show-error https://bun.sh/install | env BUN_INSTALL=/usr/local bash \
+    && bun --version \
+    && bunx --version
 
 # dioxus-cli pinned (must match the dioxus crate version in consumer
 # Cargo.toml files; bump in config.yml when the crate version moves).

--- a/rust-builder-glibc/Dockerfile
+++ b/rust-builder-glibc/Dockerfile
@@ -70,8 +70,8 @@ RUN curl --location --silent --show-error \
     | tar --extract --gzip --directory /usr/local/cargo/bin
 
 # Bun for Tailwind / asset bundling. Installed directly under /usr/local so
-# the binary lands at /usr/local/bin/bun: world-readable, already on PATH, and
-# reachable by non-root consumers without traversing /root (mode 700).
+# the binaries land at /usr/local/bin/{bun,bunx}: world-readable, already on
+# PATH, and reachable by non-root consumers without traversing /root (mode 700).
 RUN curl --fail --location --silent --show-error https://bun.sh/install | env BUN_INSTALL=/usr/local bash
 
 # dioxus-cli pinned (must match the dioxus crate version in consumer

--- a/rust-builder-glibc/config.yml
+++ b/rust-builder-glibc/config.yml
@@ -17,5 +17,5 @@ dioxus:
 
 published:
   # Published image version. Bump when any layer changes.
-  version: v1.0.0
+  version: v1.0.1
   name: rust-builder-glibc


### PR DESCRIPTION
## Summary

Publishes `rust-builder-glibc` `v1.0.1` so a tag carrying the non-root bun/bunx fix gets pushed to GHCR, and clarifies the install comment. The substance of DEV-359 (the `/root/.bun` traversal defect) was already fixed in f5fbca3 by installing bun with `BUN_INSTALL=/usr/local`; the current bun installer also lays `bunx` down in that same world-readable dir, so both binaries are reachable by any non-root UID. This bump gets that fix onto a published tag so the bunyip-web workaround (BUNYIP-54) can be dropped on the bump.

## Verification

Built `v1.0.1-rust1.94-trixie` locally and verified every acceptance criterion:

- `docker run --user 1000:1000 <image> bun --version` -> `1.3.14`
- `docker run --user 1000:1000 <image> bunx --version` -> `1.3.14`
- `/usr/local/bin/bun` is `-rwxr-xr-x` (regular file, mode 0755), `/usr/local/bin/bunx` -> `/usr/local/bin/bun`

`rust-builder-musl` was audited: it ships no bun (glibc-only by design, per the Dockerfile header), so it is unaffected.

Resolves DEV-359.