### PR TITLE
fix(rust-builder-glibc): bump dioxus-cli to 0.7.9 to match dioxus crate

### DIFF
--- a/rust-builder-glibc/Dockerfile
+++ b/rust-builder-glibc/Dockerfile
@@ -16,7 +16,7 @@ ARG DEBIAN_VARIANT=trixie
 
 FROM rust:${RUST_VERSION}-slim-${DEBIAN_VARIANT}
 
-ARG DIOXUS_CLI_VERSION=0.7.7
+ARG DIOXUS_CLI_VERSION=0.7.9
 
 # Native packages, alphabetical for diff-friendliness.
 RUN apt-get update && apt-get install --yes --no-install-recommends \

--- a/rust-builder-glibc/config.yml
+++ b/rust-builder-glibc/config.yml
@@ -13,9 +13,11 @@ debian:
 dioxus:
   # Pinned dioxus-cli version installed in the image. Must match the dioxus
   # crate version pinned in consumer Cargo.toml files.
-  version: "0.7.7"
+  version: "0.7.9"
 
 published:
   # Published image version. Bump when any layer changes.
-  version: v1.0.0
+  # v1.0.1 already exists in GHCR without a matching config commit (drift);
+  # v1.0.2 skips past it so this dx bump publishes a clean new tag.
+  version: v1.0.2
   name: rust-builder-glibc


### PR DESCRIPTION
The pinned dioxus-cli was 0.7.7 while consumers (rusty-links) resolve dioxus to 0.7.9, so `dx build` printed `dx and dioxus versions are incompatible!` and continued, risking a silently broken client bundle. Align config.dioxus.version and the Dockerfile ARG default to 0.7.9; dioxus-cli 0.7.9 exists on crates.io and is not yanked.

Bump published.version v1.0.0 -> v1.0.2 so the rebuilt image publishes a fresh tag. v1.0.1-rust1.94-trixie already exists in GHCR with no matching config.yml commit (registry/config drift); v1.0.2 skips past it rather than clobbering an existing tag.

#LINKS-19