### PR TITLE
feat(opensuse-base): add jq to base and dev images

### DIFF
--- a/opensuse-base/config.yml
+++ b/opensuse-base/config.yml
@@ -9,7 +9,7 @@ opensuse:
 
 published:
   # The openSUSE name and version are appended: v0.1.1-leap-15.6
-  version: "v1.4.0"
+  version: "v1.4.1"
   base:
     # Published image name and version
     name: "opensuse-base"
@@ -33,6 +33,8 @@ packages:
     - unzip
     - zstd
     - which
+    # JSON processor
+    - jq
     # Required for Forgejo actions
     - nodejs-common
     - nodejs24
@@ -60,6 +62,8 @@ packages:
     - unzip
     - zstd
     - which
+    # JSON processor
+    - jq
     # Required for Forgejo actions
     - nodejs-common
     - openssh-clients


### PR DESCRIPTION
jq was missing from the openSUSE base and dev images, so anything resolving JSON at runtime (e.g. the install-nushell action's "latest" version lookup, which pipes the GitHub API through jq) failed on these runners. Add jq to both package lists and bump published.version to v1.4.1 so the rebuilt images publish under a fresh tag.