### PR TITLE
feat(opensuse-dev): pre-bake Playwright browsers and dependencies

### DIFF
--- a/opensuse-base/Dockerfile
+++ b/opensuse-base/Dockerfile
@@ -40,6 +40,14 @@ FROM base AS dev
 USER root
 RUN nu /tmp/build/setup.nu install-packages --variant dev-extras
 
+# Install Playwright browser system libraries + vendored Ubuntu support libs.
+# Pre-baking these (and the browsers below) lets E2E suites run on this image
+# without Playwright's unsupported-OS fallback to apt-get.
+RUN nu /tmp/build/setup.nu install-playwright-libs
+
 # Install extra dev bun/uv packages as dev user
 USER dev
 RUN nu --login --commands "nu /tmp/build/setup.nu install-dev-extras"
+
+# Pre-download the Playwright browser binaries into the dev user's cache
+RUN nu --login --commands "nu /tmp/build/setup.nu install-playwright-browsers"

--- a/opensuse-base/config.yml
+++ b/opensuse-base/config.yml
@@ -9,7 +9,7 @@ opensuse:
 
 published:
   # The openSUSE name and version are appended: v0.1.1-leap-15.6
-  version: "v1.4.1"
+  version: "v1.5.0"
   base:
     # Published image name and version
     name: "opensuse-base"
@@ -126,6 +126,93 @@ rust:
   # There's no long-term support (LTS) model.
   # Possible value: stable
   version: "1.94"
+
+playwright:
+  # Playwright E2E browsers, pre-baked into the DEV image only, so CI never
+  # downloads browsers at test time and never hits Playwright's unsupported-OS
+  # fallback that shells out to apt-get (which does not exist on Leap).
+  # The version is keyed to both the browser builds and the vendored Ubuntu
+  # libraries below, so it MUST match the @playwright/test version consuming
+  # projects pin (mokosh-server e2e pins 1.60.0; see PMS issue).
+  version: "1.60.0"
+  browsers:
+    - chromium
+    - firefox
+    - webkit
+  # Runtime system libraries for the Playwright-bundled browsers, from the Leap
+  # 16.0 OSS repo. Chromium/Firefox need the X/GTK3/NSS set; WebKit adds GTK4,
+  # gstreamer (incl. the libav plugin for h.264), and assorted codec/text libs.
+  # Verified against opensuse/leap:16.0 by launching all three browsers headless.
+  packages:
+    # Extraction tooling for the vendored Ubuntu .debs below (provides ar).
+    - binutils
+    # Chromium + Firefox
+    - libasound2
+    - libatk-1_0-0
+    - libatk-bridge-2_0-0
+    - libatspi0
+    - libcairo2
+    - libcups2
+    - libdbus-1-3
+    - libdbus-glib-1-2
+    - libdrm2
+    - libgbm1
+    - libgtk-3-0
+    - libpango-1_0-0
+    - libX11-6
+    - libXcomposite1
+    - libXcursor1
+    - libXdamage1
+    - libXext6
+    - libXfixes3
+    - libXi6
+    - libXrandr2
+    - libXt6
+    - libxcb1
+    - libxkbcommon0
+    - libxshmfence1
+    - mozilla-nspr
+    - mozilla-nss
+    # WebKit (additional)
+    - gstreamer
+    - gstreamer-plugins-base
+    - gstreamer-plugins-good
+    - gstreamer-plugins-bad
+    - gstreamer-plugins-libav
+    - libatomic1
+    - libavif16
+    - libenchant-2-2
+    - libevent-2_1-7
+    - libglvnd
+    - libgstcodecparsers-1_0-0
+    - libgstgl-1_0-0
+    - libgstreamer-1_0-0
+    - libgtk-4-1
+    - libgudev-1_0-0
+    - libharfbuzz-icu0
+    - libhyphen0
+    - libmanette-0_2-0
+    - libnotify4
+    - libopus0
+    - libsecret-1-0
+    - libwebp7
+    - libwebpdemux2
+    - libwoff2dec1_0_2
+    - libwpe-1_0-1
+    - libWPEBackend-fdo-1_0-1
+    - libxslt1
+  # WebKit's Playwright build is compiled for Ubuntu 24.04 and hard-links ICU 74,
+  # Ubuntu's split flite voice libraries, and libx264 - none of which exist in
+  # Leap 16.0 (which ships ICU 77, a monolithic flite, and no libx264 in OSS).
+  # Vendor the exact .so files from the Ubuntu 24.04 pool into /usr/local/lib so
+  # the dynamic loader resolves them next to the system libraries. The sonames
+  # are distinct from Leap's, so they coexist (no clash with ICU 77). If a URL
+  # 404s the pool rotated the point release: bump to the current 24.04 version
+  # (same soname, ABI-compatible).
+  ubuntu_libs:
+    - https://archive.ubuntu.com/ubuntu/pool/main/i/icu/libicu74_74.2-1ubuntu3.1_amd64.deb
+    - https://archive.ubuntu.com/ubuntu/pool/universe/f/flite/libflite1_2.2-7build1_amd64.deb
+    - https://archive.ubuntu.com/ubuntu/pool/universe/x/x264/libx264-164_0.164.3108+git31e19f9-2build2_amd64.deb
 
 binaries:
   host: dufs.niceguyit.biz

--- a/opensuse-base/setup.nu
+++ b/opensuse-base/setup.nu
@@ -206,6 +206,71 @@ def "main install-dev-extras" [] {
 	print "Dev extras installed."
 }
 
+# Install Playwright browser runtime dependencies (dev stage, runs as root).
+# Two parts: the zypper system libraries, and the Ubuntu-only support libraries
+# WebKit's prebuilt (Ubuntu 24.04) binary hard-links but Leap 16.0 does not
+# ship (ICU 74, the split flite voice libraries, libx264). The Ubuntu .so files
+# are vendored into /usr/local/lib, whose distinct sonames coexist with Leap's
+# own (ICU 77, etc.), and the loader cache is refreshed so the browsers resolve
+# them. Verified against opensuse/leap:16.0 by launching all three browsers.
+def "main install-playwright-libs" [] {
+	let config = (open $config_path)
+	let pw = $config.playwright
+
+	print $"Installing Playwright system packages: ($pw.packages | str join ' ')"
+	^zypper --non-interactive --gpg-auto-import-keys refresh
+	^zypper --non-interactive install ...($pw.packages)
+
+	# Vendor the Ubuntu .so files into /usr/local/lib.
+	let vendor_dir = '/usr/local/lib/playwright'
+	let stage = '/tmp/pw-ubuntu-libs'
+	mkdir $vendor_dir
+	# Start from a clean staging dir so a re-run never collides with a leftover
+	# download (`save` refuses to overwrite, by design).
+	if ($stage | path exists) { rm --recursive $stage }
+	mkdir $stage
+	cd $stage
+
+	for url in $pw.ubuntu_libs {
+		let deb = ($url | path basename)
+		print $"Vendoring Ubuntu library: ($deb)"
+		http get $url | save $"($stage)/($deb)"
+		# A .deb is an `ar` archive; its data member is a zstd-compressed tar
+		# that lays the libraries out under ./usr/lib/x86_64-linux-gnu/.
+		^ar x $deb
+		^tar --extract --file data.tar.zst
+		rm data.tar.zst control.tar.* debian-binary $deb
+	}
+
+	# Copy every extracted shared object (preserving the version symlinks) into
+	# the vendor dir, register it with the loader, and refresh the cache.
+	let so_files = (glob $"($stage)/usr/lib/x86_64-linux-gnu/*.so*")
+	^cp --archive ...$so_files $vendor_dir
+	$"($vendor_dir)\n" | save /etc/ld.so.conf.d/playwright-webkit.conf
+	^ldconfig
+	# Leave the staging dir before removing it (cwd is inside it from the loop).
+	cd /tmp
+	rm --recursive $stage
+	^zypper --non-interactive clean --all
+	print "Playwright libraries installed."
+}
+
+# Pre-download the Playwright browser binaries into the dev user's cache (dev
+# stage, runs as the dev user). They land in ~/.cache/ms-playwright, the default
+# location Playwright reads, so a consuming project that pins the same version
+# finds them already present and skips the runtime download.
+def "main install-playwright-browsers" [] {
+	let config = (open $config_path)
+	let pw = $config.playwright
+	let spec = $"playwright@($pw.version)"
+
+	# `bun x` (not the `bunx` shim, which the bare bun binary download does not
+	# create) runs the pinned Playwright CLI to fetch the browser binaries.
+	print $"Installing Playwright browsers \(($pw.browsers | str join ', ')) via ($spec)"
+	^bun x $spec install ...($pw.browsers)
+	print "Playwright browsers installed."
+}
+
 # Main entry point (shows usage)
 def main [] {
 	print "Usage: setup.nu <subcommand>"
@@ -214,4 +279,6 @@ def main [] {
 	print "  add-user           - Create dev user and configure environment"
 	print "  install-user-tools --variant <base|dev> - Install user-level tools"
 	print "  install-dev-extras - Install only extra dev bun/uv packages"
+	print "  install-playwright-libs     - Install Playwright browser system + vendored libs (root)"
+	print "  install-playwright-browsers - Pre-download Playwright browser binaries (dev user)"
 }

--- a/opensuse-base/setup.nu
+++ b/opensuse-base/setup.nu
@@ -20,13 +20,26 @@ def "main install-packages" [
 		$config.packages | get $variant
 	}
 
+	# The dev-extras set pulls webkit2gtk3-devel (Dioxus), whose libsoup-devel
+	# dependency requires downgrading libsqlite3-0 (3.53.2 -> 3.51.3) due to Leap
+	# 16.0 repo drift: the base stage's `zypper update` bumps libsqlite3-0 past
+	# the version the dev devel-package closure resolves to. The solver treats a
+	# downgrade as a conflict and presents an interactive solution menu, which
+	# --non-interactive cancels (exit 4). --allow-downgrade lets the solver apply
+	# the downgrade automatically so the closure installs unattended.
+	let install_flags = if $variant == "dev-extras" {
+		["--allow-downgrade"]
+	} else {
+		[]
+	}
+
 	print $"Installing ($variant) packages: ($packages | str join ' ')"
 	^zypper --non-interactive --gpg-auto-import-keys refresh
 	if $variant == "base" {
 		# Only update during base install
 		^zypper --non-interactive update
 	}
-	^zypper --non-interactive install ...($packages)
+	^zypper --non-interactive install ...$install_flags ...($packages)
 	^zypper --non-interactive clean --all
 	print $"($variant) packages installed."
 }


### PR DESCRIPTION
Add @playwright/test 1.60.0 browser binaries (chromium, firefox, webkit) and all their runtime system libraries to the dev image so E2E suites run without Playwright's unsupported-OS fallback to apt-get, which does not exist on Leap and fails with exit 127.

Chromium and Firefox are fully satisfiable from the Leap 16.0 OSS repo. WebKit's Playwright build is compiled for Ubuntu 24.04 and hard-links ICU 74, Ubuntu's split flite voice libraries, and libx264, none of which exist in Leap 16.0 (which ships ICU 77, a monolithic flite, and no libx264 in OSS); these are vendored from the Ubuntu 24.04 pool into /usr/local/lib/playwright, whose distinct sonames coexist with the system libraries. Verified against opensuse/leap:16.0 by launching all three browsers headless.

Browsers download as the dev user into ~/.cache/ms-playwright so a consuming project that pins the same version finds them already present and skips the runtime download. Companion CI and workflow migration for mokosh-server tracked in PMS-423.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>